### PR TITLE
Missing floor label in Shift view

### DIFF
--- a/1080i/MyVideoNav.xml
+++ b/1080i/MyVideoNav.xml
@@ -246,7 +246,7 @@
 				<animation effect="slide" start="0" end="60" time="720" tween="cubic" easing="inout" condition="Control.IsVisible(55)">Conditional</animation>
 				<animation effect="slide" start="0,0" end="80,15" time="720" tween="cubic" easing="inout" condition="Control.IsVisible(56)">Conditional</animation>
 				<animation effect="slide" tween="cubic" time="720" start="0,806" end="0,0">VisibleChange</animation>
-				<visible>[Container.Content(movies) | Container.Content(tvshows) | Container.Content(episodes)]</visible>
+				<visible>[Container.Content(movies) | Container.Content(tvshows) | Container.Content(episodes) | Container.Content(seasons) | Container.Content(sets) | Container.Content(addons)]</visible>
 				<control type="group">
 					<left>90</left>
 					<top>1010</top>


### PR DESCRIPTION
Fixed missing FloorLabelVar for Seasons, Sets and Addons in Shift view.