### PR TITLE
Fix Floating Genre in MyFlix & Add Separate Blur Background for Video Info and ExtendedInfo

### DIFF
--- a/1080i/SkinSettings.xml
+++ b/1080i/SkinSettings.xml
@@ -754,6 +754,17 @@
 						<font>font15</font>
 						<texturenofocus border="1">separator5.png</texturenofocus>
 						<visible>System.HasAddon(script.colorbox)</visible>
+					</control>					
+					<control type="radiobutton" id="607">
+						<onclick>Skin.ToggleSetting(Enable.BlurredVideoInfoExtended)</onclick>
+						<selected>Skin.HasSetting(Enable.BlurredVideoInfoExtended)</selected>
+						<label>$LOCALIZE[31258]</label>
+						<width>1316</width>
+						<height>90</height>
+						<textoffsetx>30</textoffsetx>
+						<font>font15</font>
+						<texturenofocus border="1">separator5.png</texturenofocus>
+						<visible>System.HasAddon(script.colorbox)</visible>
 					</control>
 					<control type="radiobutton" id="601">
 						<onclick>Skin.ToggleSetting(discartoninfo)</onclick>

--- a/1080i/View_701_MyFlix.xml
+++ b/1080i/View_701_MyFlix.xml
@@ -77,6 +77,7 @@
 								<label>[COLOR labelheader]$LOCALIZE[515]:[/COLOR][CR]$INFO[ListItem.Genre]</label>
 								<width>800</width>
 								<include>DefaultButtonsValues</include>
+								<visible>!IsEmpty(ListItem.Genre)</visible>								
 							</control>
 							<control type="label">
 								<label>$VAR[FloorSubLabelVar]</label>

--- a/1080i/script-ExtendedInfo Script-DialogVideoInfo.xml
+++ b/1080i/script-ExtendedInfo Script-DialogVideoInfo.xml
@@ -29,7 +29,7 @@
 				<height>1080</height>
 				<aspectratio align="center">scale</aspectratio>
 				<texture background="true" fallback="black.png">$INFO[Window.Property(fanart)]</texture>
-				<visible>!Skin.HasSetting(Enable.BlurredVideoInfo)</visible>
+				<visible>!Skin.HasSetting(Enable.BlurredVideoInfoExtended)</visible>
 			</control>
 			<control type="image">
 				<width>1192</width>
@@ -37,19 +37,19 @@
 				<aspectratio align="center">scale</aspectratio>
 				<texture background="true" fallback="black.png">$INFO[Window.Property(ImageFilter)]</texture>
 				<fadetime>400</fadetime>
-				<visible>Skin.HasSetting(Enable.BlurredVideoInfo)</visible>
+				<visible>Skin.HasSetting(Enable.BlurredVideoInfoExtended)</visible>
 			</control>
 			<control type="image">
 				<width>1192</width>
 				<height>1080</height>
 				<texture border="4" colordiffuse="8CE5E5E5">dialogs/info/info_rightpaneltop.png</texture>
-				<visible>Skin.HasSetting(Enable.BlurredVideoInfo)</visible>
+				<visible>Skin.HasSetting(Enable.BlurredVideoInfoExtended)</visible>
 			</control>
 			<control type="image">
 				<width>1192</width>
 				<height>1080</height>
 				<texture border="4">dialogs/info/info_rightpaneltop.png</texture>
-				<visible>!Skin.HasSetting(Enable.BlurredVideoInfo)</visible>
+				<visible>!Skin.HasSetting(Enable.BlurredVideoInfoExtended)</visible>
 			</control>
 			<control type="group">
 				<left>40</left>

--- a/1080i/variables.xml
+++ b/1080i/variables.xml
@@ -579,6 +579,7 @@
 		<value condition="Control.HasFocus(600)">$LOCALIZE[31174]</value>
 		<value condition="Control.HasFocus(601)">$LOCALIZE[31982]</value>
 		<value condition="Control.HasFocus(602)">$LOCALIZE[31167]</value>
+		<value condition="Control.HasFocus(607)">$LOCALIZE[31174]</value>			
 		<value condition="Control.HasFocus(90012)">$LOCALIZE[31925]</value>
 		<value condition="Control.HasFocus(90013)">$LOCALIZE[31926]</value>
 		<value condition="Control.HasFocus(90014)">$LOCALIZE[31930]</value>

--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -716,7 +716,7 @@ msgid ""
 msgstr ""
 
 msgctxt "#31173"
-msgid "Blur background"
+msgid "Blur background (video info)"
 msgstr ""
 
 msgctxt "#31174"
@@ -978,6 +978,10 @@ msgstr ""
 
 msgctxt "#31257"
 msgid "Movie set titles"
+msgstr ""
+
+msgctxt "#31258"
+msgid "Blur background (ExtendedInfo)"
 msgstr ""
 
 msgctxt "#31300"


### PR DESCRIPTION
The first commit is a small adjustment to fix the floating text below:

![myflix-bug](https://cloud.githubusercontent.com/assets/14795587/12008109/f2ecba5a-abeb-11e5-9245-8fe970a91bb6.jpg)
