### PR TITLE
Fix Two Typos in Fullscreen Wall

### DIFF
--- a/1080i/View_609_Fullscreen_Wall.xml
+++ b/1080i/View_609_Fullscreen_Wall.xml
@@ -472,7 +472,7 @@
 					<label>$LOCALIZE[2050]:</label>
 				</control>
 				<control type="label">
-					<width>185</width>
+					<width>auto</width>
 					<font>font14</font>
 					<textcolor>grey</textcolor>
 					<label>$INFO[Window(home).Property(Set.Movies.Runtime),, minutes]</label>

--- a/1080i/View_609_Fullscreen_Wall.xml
+++ b/1080i/View_609_Fullscreen_Wall.xml
@@ -307,16 +307,27 @@
 				<texture background="true">$VAR[ArtworkLogoVar]</texture>
 			</control>
 			<control type="label">
-				<top>75</top>
+				<top>75</top>			
 				<left>397</left>
 				<width>375</width>
 				<height>15</height>
-				<font>font14</font>
+				<font>font14</font>				
 				<textcolor>$VAR[ThemeLabelColor]</textcolor>
 				<label>$INFO[ListItem.Label]</label>
 				<scroll>true</scroll>
-				<visible>IsEmpty(ListItem.Art(clearlogo))</visible>
+				<visible>IsEmpty(ListItem.Art(clearlogo)) + !ListItem.IsCollection</visible>
 			</control>
+			<control type="label">
+				<top>75</top>			
+				<left>397</left>
+				<width>750</width>
+				<height>15</height>
+				<font>font14</font>				
+				<textcolor>$VAR[ThemeLabelColor]</textcolor>
+				<label>$INFO[ListItem.Label]</label>
+				<scroll>true</scroll>
+				<visible>IsEmpty(ListItem.Art(clearlogo)) + ListItem.IsCollection</visible>
+			</control>				
 			<control type="label">
 				<top>75</top>
 				<left>787</left>


### PR DESCRIPTION
This is to fix two errors created when the Movie Information panel was added:

- auto width for grouplist item
- longer text title for collections