### PR TITLE
fix stream with tvshow- or movie-tag

### DIFF
--- a/16x9/Includes_WidgetsHome.xml
+++ b/16x9/Includes_WidgetsHome.xml
@@ -125,7 +125,7 @@
 			<control type="group">
 				<left>40</left>
 				<top>50</top>
-				<visible>VideoPlayer.Content(musicvideos) | VideoPlayer.Content(livetv) | Player.IsInternetStream</visible>
+				<visible>VideoPlayer.Content(musicvideos) | VideoPlayer.Content(livetv) | Player.IsInternetStream + ![VideoPlayer.Content(episodes) | VideoPlayer.Content(movies)]</visible>
 				<control type="group">
 					<control type="image">
 						<description>Cover image</description>


### PR DESCRIPTION
This fixes the double Cover-image, when a Internetstream (e.g. from Amazon) has a TVShow/Episode or Movie-info too
Issue-Pics: (not mine)
https://drive.google.com/open?id=0B4JpRMZvEb3sbXplQndnRFJHYlU
http://www.kodinerds.net/index.php/Attachment/12769-Vikings-PNG/