### PR TITLE
fix for aspectratio in Homescreen-widget info

### DIFF
--- a/16x9/Includes_Widgets.xml
+++ b/16x9/Includes_Widgets.xml
@@ -154,6 +154,7 @@
 				<height>310</height>
 				<texture background="true" fallback="homewidgets/DefaultMovies_poster.png">$PARAM[Texture]</texture>
 				<fadetime>IconCrossfadeTime</fadetime>
+				<aspectratio>keep</aspectratio>
 				<visible>String.IsEmpty(Window(Home).Property(Widget.CaseHome)) | String.Contains(Window(Home).Property(Widget.CaseHome),-)</visible>
 			</control>
 			<control type="image">
@@ -163,6 +164,7 @@
 				<height>298</height>
 				<texture background="true" fallback="homewidgets/DefaultMovies_poster.png">$PARAM[Texture]</texture>
 				<fadetime>IconCrossfadeTime</fadetime>
+				<aspectratio>keep</aspectratio>
 				<visible>String.Contains(Window(Home).Property(Widget.CaseHome),glass)</visible>
 			</control>
 			<control type="image">
@@ -172,6 +174,7 @@
 				<height>279</height>
 				<texture background="true" fallback="homewidgets/DefaultMovies_poster.png">$PARAM[Texture]</texture>
 				<fadetime>IconCrossfadeTime</fadetime>
+				<aspectratio>keep</aspectratio>
 				<visible>String.Contains(Window(Home).Property(Widget.CaseHome),/case)</visible>
 			</control>
 			<control type="image">
@@ -181,6 +184,7 @@
 				<height>276</height>
 				<texture background="true" fallback="homewidgets/DefaultMovies_poster.png">$PARAM[Texture]</texture>
 				<fadetime>IconCrossfadeTime</fadetime>
+				<aspectratio>keep</aspectratio>
 				<visible>String.Contains(Window(Home).Property(Widget.CaseHome),bdcase)</visible>
 			</control>
 			<control type="image">
@@ -190,6 +194,7 @@
 				<height>298</height>
 				<texture background="true" fallback="homewidgets/DefaultMovies_poster.png">$PARAM[Texture]</texture>
 				<fadetime>IconCrossfadeTime</fadetime>
+				<aspectratio>keep</aspectratio>
 				<visible>String.Contains(Window(Home).Property(Widget.CaseHome),clearcase)</visible>
 			</control>
 			<control type="image">
@@ -197,6 +202,7 @@
 				<height>310</height>
 				<texture background="true">$VAR[HomeWidget$PARAM[id]InfoCaseVar]</texture>
 				<fadetime>IconCrossfadeTime</fadetime>
+				<aspectratio>keep</aspectratio>
 				<visible>!String.IsEmpty(Window(Home).Property(Widget.CaseHome))</visible>
 			</control>
 		</control>


### PR DESCRIPTION
this fixes the wrong aspectratio for PVR-thumbs in homescreen widget "Recent Recordings", mentioned here:
http://forum.kodi.tv/showthread.php?tid=210069&pid=2383510#pid2383510
