### PR TITLE
small pvr fixes

### DIFF
--- a/16x9/Includes_LiveTV.xml
+++ b/16x9/Includes_LiveTV.xml
@@ -187,7 +187,7 @@
 						<height>38</height>
 						<font>font16</font>
 						<align>left</align>
-						<label>[B]$INFO[VideoPlayer.NextStartTime][/B]</label>
+						<label>$INFO[VideoPlayer.NextStartTime]</label>
 						<visible>!String.IsEmpty(VideoPlayer.NextStartTime)</visible>
 					</control>
 					<control type="label">
@@ -196,7 +196,7 @@
 						<font>font16</font>
 						<align>left</align>
 						<scroll>true</scroll>
-						<label>[B]$INFO[VideoPlayer.NextTitle][/B]</label>
+						<label>$INFO[VideoPlayer.NextTitle]</label>
 						<visible>!String.IsEmpty(VideoPlayer.NextTitle)</visible>
 					</control>
 				</control>
@@ -728,7 +728,7 @@
 				<top>112</top>
 				<control type="grouplist">
 					<left>300</left>
-					<width>700</width>
+					<width>1000</width>
 					<itemgap>20</itemgap>
 					<orientation>horizontal</orientation>
 					<control type="label">
@@ -761,7 +761,7 @@
 				<control type="grouplist">
 					<left>300</left>
 					<top>70</top>
-					<width>700</width>
+					<width>1000</width>
 					<itemgap>20</itemgap>
 					<orientation>horizontal</orientation>
 					<control type="label">


### PR DESCRIPTION
changed:
- removed bold-tag from bottom-line in Standard-LiveTV-OSD to make it consistent with compact-Bar
- changed width from 700 to 1000 for Compact-LiveTV-OSD
VideoPlayer.Title was cut off before