### PR TITLE
add "Find similar" and "Play programme" to DialogPVRInfo

### DIFF
--- a/16x9/DialogPVRInfo.xml
+++ b/16x9/DialogPVRInfo.xml
@@ -234,6 +234,16 @@
 							<width>auto</width>
 							<label>19687</label>
 						</control>
+					       <control type="button" id="4">
+						       <description>Find similar</description>
+						       <width>auto</width>
+						       <label>19003</label>
+					       </control>
+						<control type="button" id="10">
+							<description>Play programme</description>
+							<label>19190</label>
+							<width>auto</width>
+						</control>
 						<control type="button" id="7">
 							<description>OK</description>
 							<width>auto</width>


### PR DESCRIPTION
I added the buttons "Find similar" and "Play programme" to the menu which pops up in the PVR guide when I click on a programme and in the search results.

The button "Find similar" is already present in the master branch, but "Play programme" is missing in master. It would be great to add it there too.