### PR TITLE
myflix view - logo vertical alignment change

### DIFF
--- a/16x9/View_509_MyFlix.xml
+++ b/16x9/View_509_MyFlix.xml
@@ -31,7 +31,7 @@
 						<top>40</top>
 						<width>526</width>
 						<height>204</height>
-						<aspectratio align="left" aligny="bottom">keep</aspectratio>
+						<aspectratio align="left" aligny="center">keep</aspectratio>
 						<texture background="true">$VAR[ArtworkLogoVar]</texture>
 						<visible>[Container.Content(movies) | Container.Content(sets)] + Skin.HasSetting(Enable.MyFlix.MovieLogo) | [Container.Content(tvshows) | Container.Content(episodes)] + Skin.HasSetting(Enable.MyFlix.TVLogo)</visible>
 					</control>


### PR DESCRIPTION
Reason for the change:

The current bottom align for "aligny" works well for logos on fanart.tv since they have a strict rule about logos being 800px by 310px.

However, TMDB also introduced logos recently. TMDB doesn't have a size restriction. TMDB also does not care about any aspect ratio. It trims any transparent part around the logo and reduces the dimensions of the uploaded logo to a minimum.
Some logos are just simply text in one line and TMDB reduces them to a thin strip of text with no padding around the text at all. When aligny=bottom is used these logos sometimes sit just barely on top of the info section and this leaves a huge space above the logo empty.

Using aligny="center" nicely puts the logo in the center (vertically) leaving some space at the bottom and the top if needed.

For example, logos from TMDB and Fanart.tv for "Dynasties":
https://www.themoviedb.org/tv/82953-dynasties/images/logos
https://fanart.tv/series/352054/dynasties-2019/

See screenshots below for clarity - used logos from TMDB (since it's the default TV show scrapper for Kodi now):

Before Change:
![image](https://user-images.githubusercontent.com/14898578/185252401-c2026535-06e5-4d65-8fa1-39ebc635d008.png)

After Change:

![image](https://user-images.githubusercontent.com/14898578/185252773-f5ddd417-3e88-4d53-9073-ee931b6d2842.png)


